### PR TITLE
Add assertions to switch statements

### DIFF
--- a/src/main/java/kronos/commands/AddCommand.java
+++ b/src/main/java/kronos/commands/AddCommand.java
@@ -113,8 +113,7 @@ public class AddCommand implements Command {
             newTask = new Event(description, startDate, endDate);
             break;
         default:
-            // If the task type is not recognized, throw an exception
-            throw new IllegalArgumentException("What kind of task is " + taskType + "?");
+            assert false : "Unexpected task type: " + taskType;
         }
 
         // Add the new task to the list


### PR DESCRIPTION
Switch statements currently throw exceptions in the default cases.

Logical errors should terminate the program instead of continuing.

Let's change the thrown exception with an appropriate assert statement.

It is more fitting to use assertion errors than throwing exceptions to handle logic errors.

Assertions are a form of defensive programming that perform logic checks on your program. Code handling I/O operations is an example of using exceptions instead of assertions